### PR TITLE
Fix crash when downloading from ftp

### DIFF
--- a/curler.cpp
+++ b/curler.cpp
@@ -273,7 +273,13 @@ static HEADERS get_headers(const std::string &url)
     }
 
     headers["length"] = static_cast<long>(content_length);
-    headers["filetype"] = mimetypes[content_type];
+    if (content_type)
+	headers["filetype"] = mimetypes[content_type];
+    else {  // Didn't find content-type. Try to get extension from the url.
+	std::string ct = url.substr(url.rfind('.'), url.back());
+	if (ct.length() > 0)
+	    headers["filetype"] = ct;
+    }
 
     curl_easy_cleanup(curl);
 


### PR DESCRIPTION
When downloading from ftp there isn't any content-type header so it was never changed from nullptr. This will also fix any occurances of this issue with HTTP downloads as well.