### PR TITLE
Re-use existing connections after looking up header info

### DIFF
--- a/src/curler.h
+++ b/src/curler.h
@@ -3,9 +3,7 @@
 
 #include <string>
 
-/* Tries to determine the filename automatically from the headers/url */
-bool download(const std::string &path, const std::string &url);
-/* Downloads file from the url and saves it as 'filename' */
-bool download(const std::string &path, const std::string &filename, const std::string &url);
+bool download(const std::string &url, const std::string &path,
+	      const std::string &filename);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,10 +31,7 @@ int main(int argc, char *argv[])
 
 	for (const urldata &url : urls) {
 	    if (url.url.length() > 0) {
-		if (url.filename.length() == 0)
-		    res = download(url.path, url.url);
-		else
-		    res = download(url.path, url.filename, url.url);
+		download(url.url, url.path, url.filename);
 		if (!res) log(err[FILE_ERR_DOWNLOAD], url.filename);
 	    } else log(err[URL_ERR_EMPTY]);
 	}


### PR DESCRIPTION
Major refactor to make sure we re-use existing connections that we
establish while looking up header info. Maybe this optimizes things a
bit.

This commit also simplifies the header lookup info by rolling in the
content-disposition stuff into get_headers(), and also does away with
the three separate download functions. Instead I created a unified
download function, and separated out all the non-relevant parts into
their own more logically named functions.